### PR TITLE
Authentication workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,13 +17,13 @@ RUN mvn package
 
 FROM openjdk:8-slim as runtime
 # Expose the port
-EXPOSE 8085
+EXPOSE 8080
 #Set app home folder
 ENV APP_HOME /app
 #Possibility to set JVM options (https://www.oracle.com/technetwork/java/javase/tech/vmoptions-jsp-140102.html)
 ENV JAVA_OPTS=""
 # Set ENV variables
-ENV PORT=8085
+ENV PORT=8080
 ENV DISCOVERY_URL="http://discovery:8761"
 
 #Create base app folder

--- a/README.md
+++ b/README.md
@@ -23,5 +23,5 @@ This build should work for both macOS and Linux
 ## Health Endpoint
 
 Confirm everything was ran correctly by going to the following endpoint: 
-  * http://localhost:8085/health/v1/marco
+  * http://localhost:8080/health/v1/marco
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # User-Interaction Microservices
 
+The sole purpose of this repository is to authenticate a user and produce a JWT token that other services can use
+
 **Note:** 
   * You will only need docker installed on your computer to run this app
 
@@ -15,9 +17,8 @@
 This build should work for both macOS and Linux
 
 1. Download docker for your operating system
-2. From project root run the following commands:
-  * **Build:** `docker build -t user-service .`
-  * **Run:** `docker run -d=true -p 8085:8085 user-service`
+2. From project root run the following command:
+    * `docker-compose up --build`
 
 ## Health Endpoint
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '3.7'
+services:
+  user-interaction:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+  db:
+    image: postgres:9.4
+    ports:
+      - "5433:5433"
+    volumes:
+      - type: volume
+        source: dbdata
+        target: "/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_PASSWORD=password
+  pgAdmin:
+    image: dpage/pgadmin4
+    ports:
+      - "9001:80"
+    volumes:
+      - type: volume
+        source: pgadmindata
+        target: "/var/lib/pgadmin"
+    environment:
+      - PGADMIN_DEFAULT_EMAIL=test@test.com
+      - PGADMIN_DEFAULT_PASSWORD=test
+volumes:
+  dbdata:
+  pgadmindata:

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,39 @@
 	<dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-jpa</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-oauth2-client</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.postgresql</groupId>
+			<artifactId>postgresql</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt</artifactId>
+			<version>0.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.security</groupId>
+			<artifactId>spring-security-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
@@ -30,9 +63,10 @@
 		</dependency>
 
 		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
+			<groupId>com.h2database</groupId>
+			<artifactId>h2</artifactId>
 			<scope>test</scope>
+			<version>1.4.194</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/com/fcgl/madrid/MadridApplication.java
+++ b/src/main/java/com/fcgl/madrid/MadridApplication.java
@@ -1,11 +1,14 @@
 package com.fcgl.madrid;
 
+import com.fcgl.madrid.user.configuration.AppProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 
 @EnableEurekaClient
 @SpringBootApplication
+@EnableConfigurationProperties(AppProperties.class)
 public class MadridApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
+++ b/src/main/java/com/fcgl/madrid/dev/DataPopulation.java
@@ -1,0 +1,36 @@
+package com.fcgl.madrid.dev;
+
+import com.fcgl.madrid.user.dataModel.AuthProvider;
+import com.fcgl.madrid.user.dataModel.User;
+import com.fcgl.madrid.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import javax.annotation.PostConstruct;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DataPopulation {
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public DataPopulation(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Transactional
+    @PostConstruct
+    public void init() {
+        User user = new User();
+        user.setName("FCGL TEST");
+        user.setEmail("test@fcgl.io");
+        user.setPassword("password");
+        user.setProvider(AuthProvider.local);
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+
+        User result = userRepository.save(user);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/configuration/AppProperties.java
+++ b/src/main/java/com/fcgl/madrid/user/configuration/AppProperties.java
@@ -1,0 +1,54 @@
+package com.fcgl.madrid.user.configuration;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app")
+public class AppProperties {
+    private final Auth auth = new Auth();
+    private final OAuth2 oauth2 = new OAuth2();
+
+    public static class Auth {
+        private String tokenSecret;
+        private long tokenExpirationMsec;
+
+        public String getTokenSecret() {
+            return tokenSecret;
+        }
+
+        public void setTokenSecret(String tokenSecret) {
+            this.tokenSecret = tokenSecret;
+        }
+
+        public long getTokenExpirationMsec() {
+            return tokenExpirationMsec;
+        }
+
+        public void setTokenExpirationMsec(long tokenExpirationMsec) {
+            this.tokenExpirationMsec = tokenExpirationMsec;
+        }
+    }
+
+    public static final class OAuth2 {
+        private List<String> authorizedRedirectUris = new ArrayList<>();
+
+        public List<String> getAuthorizedRedirectUris() {
+            return authorizedRedirectUris;
+        }
+
+        public OAuth2 authorizedRedirectUris(List<String> authorizedRedirectUris) {
+            this.authorizedRedirectUris = authorizedRedirectUris;
+            return this;
+        }
+    }
+
+    public Auth getAuth() {
+        return auth;
+    }
+
+    public OAuth2 getOauth2() {
+        return oauth2;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/configuration/SecurityConfig.java
+++ b/src/main/java/com/fcgl/madrid/user/configuration/SecurityConfig.java
@@ -1,0 +1,134 @@
+package com.fcgl.madrid.user.configuration;
+
+import com.fcgl.madrid.user.security.*;
+import com.fcgl.madrid.user.security.oauth2.CustomOAuth2UserService;
+import com.fcgl.madrid.user.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository;
+import com.fcgl.madrid.user.security.oauth2.OAuth2AuthenticationFailureHandler;
+import com.fcgl.madrid.user.security.oauth2.OAuth2AuthenticationSuccessHandler;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.BeanIds;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@EnableGlobalMethodSecurity(
+        securedEnabled = true,
+        jsr250Enabled = true,
+        prePostEnabled = true
+)
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Autowired
+    private CustomOAuth2UserService customOAuth2UserService;
+
+    @Autowired
+    private OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+
+    @Autowired
+    private OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
+
+    @Autowired
+    private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Bean
+    public TokenAuthenticationFilter tokenAuthenticationFilter() {
+        return new TokenAuthenticationFilter();
+    }
+
+    /*
+      By default, Spring OAuth2 uses HttpSessionOAuth2AuthorizationRequestRepository to save
+      the authorization request. But, since our service is stateless, we can't save it in
+      the session. We'll save the request in a Base64 encoded cookie instead.
+    */
+    @Bean
+    public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
+        return new HttpCookieOAuth2AuthorizationRequestRepository();
+    }
+
+    @Override
+    public void configure(AuthenticationManagerBuilder authenticationManagerBuilder) throws Exception {
+        authenticationManagerBuilder
+                .userDetailsService(customUserDetailsService)
+                .passwordEncoder(passwordEncoder());
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Bean(BeanIds.AUTHENTICATION_MANAGER)
+    @Override
+    public AuthenticationManager authenticationManagerBean() throws Exception {
+        return super.authenticationManagerBean();
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .cors()
+                .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                .and()
+                .csrf()
+                .disable()
+                .formLogin()
+                .disable()
+                .httpBasic()
+                .disable()
+                .exceptionHandling()
+                .authenticationEntryPoint(new RestAuthenticationEntryPoint())
+                .and()
+                .authorizeRequests()
+                .antMatchers("/",
+                        "/error",
+                        "/favicon.ico",
+                        "/**/*.png",
+                        "/**/*.gif",
+                        "/**/*.svg",
+                        "/**/*.jpg",
+                        "/**/*.html",
+                        "/**/*.css",
+                        "/**/*.js")
+                .permitAll()
+                .antMatchers("/auth/**", "/oauth2/**")
+                .permitAll()
+                .anyRequest()
+                .authenticated()
+                .and()
+                .oauth2Login()
+                .authorizationEndpoint()
+                .baseUri("/oauth2/authorize")
+                .authorizationRequestRepository(cookieAuthorizationRequestRepository())
+                .and()
+                .redirectionEndpoint()
+                .baseUri("/oauth2/callback/*")
+                .and()
+                .userInfoEndpoint()
+                .userService(customOAuth2UserService)
+                .and()
+                .successHandler(oAuth2AuthenticationSuccessHandler)
+                .failureHandler(oAuth2AuthenticationFailureHandler);
+
+        // Add our custom Token based authentication filter
+        http.addFilterBefore(tokenAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/configuration/WebMvcConfig.java
+++ b/src/main/java/com/fcgl/madrid/user/configuration/WebMvcConfig.java
@@ -1,0 +1,24 @@
+package com.fcgl.madrid.user.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * TODO: We are going to want to limit this to only within our app on production, this is okay for dev for testing
+ */
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final long MAX_AGE_SECS = 3600;
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("*")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true)
+                .maxAge(MAX_AGE_SECS);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/controller/AuthController.java
+++ b/src/main/java/com/fcgl/madrid/user/controller/AuthController.java
@@ -1,0 +1,35 @@
+package com.fcgl.madrid.user.controller;
+
+import com.fcgl.madrid.user.payload.LoginRequest;
+import com.fcgl.madrid.user.payload.SignUpRequest;
+import com.fcgl.madrid.user.service.AuthService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private AuthService authService;
+
+    @Autowired
+    public void setAuthService(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+        return authService.authenticateUser(loginRequest);
+    }
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> registerUser(@Valid @RequestBody SignUpRequest signUpRequest) {
+        return authService.registerUser(signUpRequest);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/controller/UserController.java
+++ b/src/main/java/com/fcgl/madrid/user/controller/UserController.java
@@ -1,0 +1,25 @@
+package com.fcgl.madrid.user.controller;
+
+import com.fcgl.madrid.user.dataModel.User;
+import com.fcgl.madrid.user.exception.ResourceNotFoundException;
+import com.fcgl.madrid.user.repository.UserRepository;
+import com.fcgl.madrid.user.security.CurrentUser;
+import com.fcgl.madrid.user.security.UserPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class UserController {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @GetMapping("/user/me")
+    @PreAuthorize("hasRole('USER')")
+    public User getCurrentUser(@CurrentUser UserPrincipal userPrincipal) {
+        return userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/dataModel/AuthProvider.java
+++ b/src/main/java/com/fcgl/madrid/user/dataModel/AuthProvider.java
@@ -1,0 +1,8 @@
+package com.fcgl.madrid.user.dataModel;
+
+public enum  AuthProvider {
+    local,
+    facebook,
+    google,
+    github
+}

--- a/src/main/java/com/fcgl/madrid/user/dataModel/User.java
+++ b/src/main/java/com/fcgl/madrid/user/dataModel/User.java
@@ -1,0 +1,104 @@
+package com.fcgl.madrid.user.dataModel;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import javax.persistence.*;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotNull;
+
+@Entity
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(columnNames = "email")
+})
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Email
+    @Column(nullable = false)
+    private String email;
+
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private Boolean emailVerified = false;
+
+    @JsonIgnore
+    private String password;
+
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    private AuthProvider provider;
+
+    private String providerId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getImageUrl() {
+        return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public Boolean getEmailVerified() {
+        return emailVerified;
+    }
+
+    public void setEmailVerified(Boolean emailVerified) {
+        this.emailVerified = emailVerified;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public AuthProvider getProvider() {
+        return provider;
+    }
+
+    public void setProvider(AuthProvider provider) {
+        this.provider = provider;
+    }
+
+    public String getProviderId() {
+        return providerId;
+    }
+
+    public void setProviderId(String providerId) {
+        this.providerId = providerId;
+    }
+
+    // Getters and Setters (Omitted for brevity)
+}

--- a/src/main/java/com/fcgl/madrid/user/exception/BadRequestException.java
+++ b/src/main/java/com/fcgl/madrid/user/exception/BadRequestException.java
@@ -1,0 +1,15 @@
+package com.fcgl.madrid.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+
+    public BadRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/exception/OAuth2AuthenticationProcessingException.java
+++ b/src/main/java/com/fcgl/madrid/user/exception/OAuth2AuthenticationProcessingException.java
@@ -1,0 +1,13 @@
+package com.fcgl.madrid.user.exception;
+
+import org.springframework.security.core.AuthenticationException;
+
+public class OAuth2AuthenticationProcessingException extends AuthenticationException {
+    public OAuth2AuthenticationProcessingException(String msg, Throwable t) {
+        super(msg, t);
+    }
+
+    public OAuth2AuthenticationProcessingException(String msg) {
+        super(msg);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/exception/ResourceNotFoundException.java
+++ b/src/main/java/com/fcgl/madrid/user/exception/ResourceNotFoundException.java
@@ -1,0 +1,30 @@
+package com.fcgl.madrid.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class ResourceNotFoundException extends RuntimeException {
+    private String resourceName;
+    private String fieldName;
+    private Object fieldValue;
+
+    public ResourceNotFoundException(String resourceName, String fieldName, Object fieldValue) {
+        super(String.format("%s not found with %s : '%s'", resourceName, fieldName, fieldValue));
+        this.resourceName = resourceName;
+        this.fieldName = fieldName;
+        this.fieldValue = fieldValue;
+    }
+
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    public String getFieldName() {
+        return fieldName;
+    }
+
+    public Object getFieldValue() {
+        return fieldValue;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/model/FacebookOAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/model/FacebookOAuth2UserInfo.java
@@ -1,0 +1,40 @@
+package com.fcgl.madrid.user.model;
+
+import com.fcgl.madrid.user.security.oauth2.user.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class FacebookOAuth2UserInfo extends OAuth2UserInfo {
+    public FacebookOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        if(attributes.containsKey("picture")) {
+            Map<String, Object> pictureObj = (Map<String, Object>) attributes.get("picture");
+            if(pictureObj.containsKey("data")) {
+                Map<String, Object>  dataObj = (Map<String, Object>) pictureObj.get("data");
+                if(dataObj.containsKey("url")) {
+                    return (String) dataObj.get("url");
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/model/GithubOAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/model/GithubOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.fcgl.madrid.user.model;
+
+import com.fcgl.madrid.user.security.oauth2.user.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class GithubOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GithubOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return ((Integer) attributes.get("id")).toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("avatar_url");
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/model/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/model/GoogleOAuth2UserInfo.java
@@ -1,0 +1,32 @@
+package com.fcgl.madrid.user.model;
+
+import com.fcgl.madrid.user.security.oauth2.user.OAuth2UserInfo;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/payload/ApiResponse.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/ApiResponse.java
@@ -1,0 +1,29 @@
+package com.fcgl.madrid.user.payload;
+
+public class ApiResponse {
+    private boolean success;
+    private String message;
+
+    public ApiResponse(boolean success, String message) {
+        this.success = success;
+        this.message = message;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    // Getters and Setters (Omitted for brevity)
+}

--- a/src/main/java/com/fcgl/madrid/user/payload/AuthResponse.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/AuthResponse.java
@@ -1,0 +1,28 @@
+package com.fcgl.madrid.user.payload;
+
+public class AuthResponse {
+    private String accessToken;
+    private String tokenType = "Bearer";
+
+    public AuthResponse(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getAccessToken() {
+        return accessToken;
+    }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
+
+    public String getTokenType() {
+        return tokenType;
+    }
+
+    public void setTokenType(String tokenType) {
+        this.tokenType = tokenType;
+    }
+
+    // Getters and Setters (Omitted for brevity)
+}

--- a/src/main/java/com/fcgl/madrid/user/payload/LoginRequest.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/LoginRequest.java
@@ -1,0 +1,31 @@
+package com.fcgl.madrid.user.payload;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public class LoginRequest {
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    // Getters and Setters (Omitted for brevity)
+}

--- a/src/main/java/com/fcgl/madrid/user/payload/SignUpRequest.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/SignUpRequest.java
@@ -1,0 +1,42 @@
+package com.fcgl.madrid.user.payload;
+
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+
+public class SignUpRequest {
+    @NotBlank
+    private String name;
+
+    @NotBlank
+    @Email
+    private String email;
+
+    @NotBlank
+    private String password;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    // Getters and Setters (Omitted for brevity)
+}

--- a/src/main/java/com/fcgl/madrid/user/repository/UserRepository.java
+++ b/src/main/java/com/fcgl/madrid/user/repository/UserRepository.java
@@ -1,0 +1,16 @@
+package com.fcgl.madrid.user.repository;
+
+import com.fcgl.madrid.user.dataModel.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+
+    Boolean existsByEmail(String email);
+
+}

--- a/src/main/java/com/fcgl/madrid/user/security/CurrentUser.java
+++ b/src/main/java/com/fcgl/madrid/user/security/CurrentUser.java
@@ -1,0 +1,12 @@
+package com.fcgl.madrid.user.security;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import java.lang.annotation.*;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@AuthenticationPrincipal
+public @interface CurrentUser {
+
+}

--- a/src/main/java/com/fcgl/madrid/user/security/CustomUserDetailsService.java
+++ b/src/main/java/com/fcgl/madrid/user/security/CustomUserDetailsService.java
@@ -1,0 +1,39 @@
+package com.fcgl.madrid.user.security;
+
+import com.fcgl.madrid.user.dataModel.User;
+import com.fcgl.madrid.user.exception.ResourceNotFoundException;
+import com.fcgl.madrid.user.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    @Autowired
+    UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public UserDetails loadUserByUsername(String email)
+            throws UsernameNotFoundException {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() ->
+                        new UsernameNotFoundException("User not found with email : " + email)
+                );
+
+        return UserPrincipal.create(user);
+    }
+
+    @Transactional
+    public UserDetails loadUserById(Long id) {
+        User user = userRepository.findById(id).orElseThrow(
+                () -> new ResourceNotFoundException("User", "id", id)
+        );
+
+        return UserPrincipal.create(user);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/RestAuthenticationEntryPoint.java
+++ b/src/main/java/com/fcgl/madrid/user/security/RestAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package com.fcgl.madrid.user.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class RestAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private static final Logger logger = LoggerFactory.getLogger(RestAuthenticationEntryPoint.class);
+
+    @Override
+    public void commence(HttpServletRequest httpServletRequest,
+                         HttpServletResponse httpServletResponse,
+                         AuthenticationException e) throws IOException, ServletException {
+        logger.error("Responding with unauthorized error. Message - {}", e.getMessage());
+        httpServletResponse.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+                e.getLocalizedMessage());
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/fcgl/madrid/user/security/TokenAuthenticationFilter.java
@@ -1,0 +1,57 @@
+package com.fcgl.madrid.user.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class TokenAuthenticationFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenAuthenticationFilter.class);
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwt = getJwtFromRequest(request);
+
+            if (StringUtils.hasText(jwt) && tokenProvider.validateToken(jwt)) {
+                Long userId = tokenProvider.getUserIdFromToken(jwt);
+
+                UserDetails userDetails = customUserDetailsService.loadUserById(userId);
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception ex) {
+            logger.error("Could not set user authentication in security context", ex);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/TokenProvider.java
+++ b/src/main/java/com/fcgl/madrid/user/security/TokenProvider.java
@@ -1,0 +1,72 @@
+package com.fcgl.madrid.user.security;
+
+import com.fcgl.madrid.user.configuration.AppProperties;
+import io.jsonwebtoken.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Date;
+
+@Service
+public class TokenProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(TokenProvider.class);
+
+    private AppProperties appProperties;
+
+    public TokenProvider(AppProperties appProperties) {
+        this.appProperties = appProperties;
+    }
+
+    public String createToken(Authentication authentication) {
+        UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal();
+
+        Date now = new Date();
+        Date expiryDate = new Date(now.getTime() + appProperties.getAuth().getTokenExpirationMsec());
+        final Map<String, Object> tokenData = new HashMap<>();
+        List<String> roles = new ArrayList<String>();
+        //TODO: Add some ROLE architecture
+        roles.add("ROLE_USER");
+        tokenData.put("authorities", roles);
+
+        return Jwts.builder()
+                .setClaims(tokenData)
+                .setSubject(Long.toString(userPrincipal.getId()))
+                .setIssuedAt(new Date())
+                .setExpiration(expiryDate)
+                .signWith(SignatureAlgorithm.HS512, appProperties.getAuth().getTokenSecret())
+                .compact();
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = Jwts.parser()
+                .setSigningKey(appProperties.getAuth().getTokenSecret())
+                .parseClaimsJws(token)
+                .getBody();
+
+        return Long.parseLong(claims.getSubject());
+    }
+
+    public boolean validateToken(String authToken) {
+        try {
+            Jwts.parser().setSigningKey(appProperties.getAuth().getTokenSecret()).parseClaimsJws(authToken);
+            return true;
+        } catch (SignatureException ex) {
+            logger.error("Invalid JWT signature");
+        } catch (MalformedJwtException ex) {
+            logger.error("Invalid JWT token");
+        } catch (ExpiredJwtException ex) {
+            logger.error("Expired JWT token");
+        } catch (UnsupportedJwtException ex) {
+            logger.error("Unsupported JWT token");
+        } catch (IllegalArgumentException ex) {
+            logger.error("JWT claims string is empty.");
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/UserPrincipal.java
+++ b/src/main/java/com/fcgl/madrid/user/security/UserPrincipal.java
@@ -1,0 +1,102 @@
+package com.fcgl.madrid.user.security;
+
+import com.fcgl.madrid.user.dataModel.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+public class UserPrincipal implements OAuth2User, UserDetails {
+    private Long id;
+    private String email;
+    private String password;
+    private Collection<? extends GrantedAuthority> authorities;
+    private Map<String, Object> attributes;
+
+    public UserPrincipal(Long id, String email, String password, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.email = email;
+        this.password = password;
+        this.authorities = authorities;
+    }
+
+    public static UserPrincipal create(User user) {
+        List<GrantedAuthority> authorities = Collections.
+                singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+        return new UserPrincipal(
+                user.getId(),
+                user.getEmail(),
+                user.getPassword(),
+                authorities
+        );
+    }
+
+    public static UserPrincipal create(User user, Map<String, Object> attributes) {
+        UserPrincipal userPrincipal = UserPrincipal.create(user);
+        userPrincipal.setAttributes(attributes);
+        return userPrincipal;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return email;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public void setAttributes(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(id);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,82 @@
+package com.fcgl.madrid.user.security.oauth2;
+
+import com.fcgl.madrid.user.dataModel.AuthProvider;
+import com.fcgl.madrid.user.dataModel.User;
+import com.fcgl.madrid.user.exception.OAuth2AuthenticationProcessingException;
+import com.fcgl.madrid.user.security.oauth2.user.OAuth2UserInfo;
+import com.fcgl.madrid.user.security.oauth2.user.OAuth2UserInfoFactory;
+import com.fcgl.madrid.user.repository.UserRepository;
+import com.fcgl.madrid.user.security.UserPrincipal;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+import java.util.Optional;
+
+@Service
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest oAuth2UserRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(oAuth2UserRequest);
+
+        try {
+            return processOAuth2User(oAuth2UserRequest, oAuth2User);
+        } catch (AuthenticationException ex) {
+            throw ex;
+        } catch (Exception ex) {
+            // Throwing an instance of AuthenticationException will trigger the OAuth2AuthenticationFailureHandler
+            throw new InternalAuthenticationServiceException(ex.getMessage(), ex.getCause());
+        }
+    }
+
+    private OAuth2User processOAuth2User(OAuth2UserRequest oAuth2UserRequest, OAuth2User oAuth2User) {
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(oAuth2UserRequest.getClientRegistration().getRegistrationId(), oAuth2User.getAttributes());
+        if(StringUtils.isEmpty(oAuth2UserInfo.getEmail())) {
+            throw new OAuth2AuthenticationProcessingException("Email not found from OAuth2 provider");
+        }
+
+        Optional<User> userOptional = userRepository.findByEmail(oAuth2UserInfo.getEmail());
+        User user;
+        if(userOptional.isPresent()) {
+            user = userOptional.get();
+            if(!user.getProvider().equals(AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()))) {
+                throw new OAuth2AuthenticationProcessingException("Looks like you're signed up with " +
+                        user.getProvider() + " account. Please use your " + user.getProvider() +
+                        " account to login.");
+            }
+            user = updateExistingUser(user, oAuth2UserInfo);
+        } else {
+            user = registerNewUser(oAuth2UserRequest, oAuth2UserInfo);
+        }
+
+        return UserPrincipal.create(user, oAuth2User.getAttributes());
+    }
+
+    private User registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
+        User user = new User();
+
+        user.setProvider(AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()));
+        user.setProviderId(oAuth2UserInfo.getId());
+        user.setName(oAuth2UserInfo.getName());
+        user.setEmail(oAuth2UserInfo.getEmail());
+        user.setImageUrl(oAuth2UserInfo.getImageUrl());
+        return userRepository.save(user);
+    }
+
+    private User updateExistingUser(User existingUser, OAuth2UserInfo oAuth2UserInfo) {
+        existingUser.setName(oAuth2UserInfo.getName());
+        existingUser.setImageUrl(oAuth2UserInfo.getImageUrl());
+        return userRepository.save(existingUser);
+    }
+
+}

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,49 @@
+package com.fcgl.madrid.user.security.oauth2;
+
+import com.fcgl.madrid.user.util.CookieUtils;
+import com.nimbusds.oauth2.sdk.util.StringUtils;//???
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class HttpCookieOAuth2AuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+            CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+            return;
+        }
+
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+        return this.loadAuthorizationRequest(request);
+    }
+
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,39 @@
+package com.fcgl.madrid.user.security.oauth2;
+
+import com.fcgl.madrid.user.util.CookieUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import com.fcgl.madrid.user.util.CookieUtils;
+import static com.fcgl.madrid.user.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Autowired
+    HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String targetUrl = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue)
+                .orElse(("/"));
+
+        targetUrl = UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("error", exception.getLocalizedMessage())
+                .build().toUriString();
+
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,95 @@
+package com.fcgl.madrid.user.security.oauth2;
+
+import com.fcgl.madrid.user.configuration.AppProperties;
+import com.fcgl.madrid.user.exception.BadRequestException;
+import com.fcgl.madrid.user.security.TokenProvider;
+import com.fcgl.madrid.user.util.CookieUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Optional;
+
+import static com.fcgl.madrid.user.security.oauth2.HttpCookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME;
+
+@Component
+public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private TokenProvider tokenProvider;
+
+    private AppProperties appProperties;
+
+    private HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
+
+
+    @Autowired
+    OAuth2AuthenticationSuccessHandler(TokenProvider tokenProvider, AppProperties appProperties,
+                                       HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository) {
+        this.tokenProvider = tokenProvider;
+        this.appProperties = appProperties;
+        this.httpCookieOAuth2AuthorizationRequestRepository = httpCookieOAuth2AuthorizationRequestRepository;
+    }
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
+        String targetUrl = determineTargetUrl(request, response, authentication);
+
+        if (response.isCommitted()) {
+            logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
+            return;
+        }
+
+        clearAuthenticationAttributes(request, response);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+        Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
+                .map(Cookie::getValue);
+
+        if(redirectUri.isPresent() && !isAuthorizedRedirectUri(redirectUri.get())) {
+            throw new BadRequestException("Sorry! We've got an Unauthorized Redirect URI and can't proceed with the authentication");
+        }
+
+        String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
+
+        String token = tokenProvider.createToken(authentication);
+        return UriComponentsBuilder.fromUriString(targetUrl)
+                .queryParam("token", token)
+                .build().toUriString();
+    }
+
+    protected void clearAuthenticationAttributes(HttpServletRequest request, HttpServletResponse response) {
+        super.clearAuthenticationAttributes(request);
+        httpCookieOAuth2AuthorizationRequestRepository.removeAuthorizationRequestCookies(request, response);
+    }
+
+    /**
+     * This has to change for react native
+     * @param uri
+     * @return
+     */
+    private boolean isAuthorizedRedirectUri(String uri) {
+        URI clientRedirectUri = URI.create(uri);
+
+        return appProperties.getOauth2().getAuthorizedRedirectUris()
+                .stream()
+                .anyMatch(authorizedRedirectUri -> {
+                    // Only validate host and port. Let the clients use different paths if they want to
+                    URI authorizedURI = URI.create(authorizedRedirectUri);
+                    if(authorizedURI.getHost().equalsIgnoreCase(clientRedirectUri.getHost())
+                            && authorizedURI.getPort() == clientRedirectUri.getPort()) {
+                        return true;
+                    }
+                    return false;
+                });
+    }
+}
+

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/user/FacebookOAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/user/FacebookOAuth2UserInfo.java
@@ -1,0 +1,39 @@
+package com.fcgl.madrid.user.security.oauth2.user;
+
+import java.util.Map;
+
+public class FacebookOAuth2UserInfo extends OAuth2UserInfo {
+    public FacebookOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        if(attributes.containsKey("picture")) {
+            Map<String, Object> pictureObj = (Map<String, Object>) attributes.get("picture");
+            if(pictureObj.containsKey("data")) {
+                Map<String, Object>  dataObj = (Map<String, Object>) pictureObj.get("data");
+                if(dataObj.containsKey("url")) {
+                    return (String) dataObj.get("url");
+                }
+            }
+        }
+        return null;
+    }
+}
+

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/user/GithubOAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/user/GithubOAuth2UserInfo.java
@@ -1,0 +1,30 @@
+package com.fcgl.madrid.user.security.oauth2.user;
+
+import java.util.Map;
+
+public class GithubOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GithubOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return ((Integer) attributes.get("id")).toString();
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("avatar_url");
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/user/GoogleOAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/user/GoogleOAuth2UserInfo.java
@@ -1,0 +1,31 @@
+package com.fcgl.madrid.user.security.oauth2.user;
+
+import java.util.Map;
+
+public class GoogleOAuth2UserInfo extends OAuth2UserInfo {
+
+    public GoogleOAuth2UserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getId() {
+        return (String) attributes.get("sub");
+    }
+
+    @Override
+    public String getName() {
+        return (String) attributes.get("name");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getImageUrl() {
+        return (String) attributes.get("picture");
+    }
+}
+

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/user/OAuth2UserInfo.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/user/OAuth2UserInfo.java
@@ -1,0 +1,23 @@
+package com.fcgl.madrid.user.security.oauth2.user;
+
+import java.util.Map;
+
+public abstract class OAuth2UserInfo {
+    protected Map<String, Object> attributes;
+
+    public OAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public abstract String getId();
+
+    public abstract String getName();
+
+    public abstract String getEmail();
+
+    public abstract String getImageUrl();
+}

--- a/src/main/java/com/fcgl/madrid/user/security/oauth2/user/OAuth2UserInfoFactory.java
+++ b/src/main/java/com/fcgl/madrid/user/security/oauth2/user/OAuth2UserInfoFactory.java
@@ -1,0 +1,24 @@
+package com.fcgl.madrid.user.security.oauth2.user;
+
+import com.fcgl.madrid.user.dataModel.AuthProvider;
+import com.fcgl.madrid.user.exception.OAuth2AuthenticationProcessingException;
+import com.fcgl.madrid.user.model.FacebookOAuth2UserInfo;
+import com.fcgl.madrid.user.model.GithubOAuth2UserInfo;
+import com.fcgl.madrid.user.model.GoogleOAuth2UserInfo;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+
+    public static OAuth2UserInfo getOAuth2UserInfo(String registrationId, Map<String, Object> attributes) {
+        if(registrationId.equalsIgnoreCase(AuthProvider.google.toString())) {
+            return new GoogleOAuth2UserInfo(attributes);
+        } else if (registrationId.equalsIgnoreCase(AuthProvider.facebook.toString())) {
+            return new FacebookOAuth2UserInfo(attributes);
+        } else if (registrationId.equalsIgnoreCase(AuthProvider.github.toString())) {
+            return new GithubOAuth2UserInfo(attributes);
+        } else {
+            throw new OAuth2AuthenticationProcessingException("Sorry! Login with " + registrationId + " is not supported yet.");
+        }
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/service/AuthService.java
+++ b/src/main/java/com/fcgl/madrid/user/service/AuthService.java
@@ -1,0 +1,78 @@
+package com.fcgl.madrid.user.service;
+
+import com.fcgl.madrid.user.dataModel.AuthProvider;
+import com.fcgl.madrid.user.dataModel.User;
+import com.fcgl.madrid.user.exception.BadRequestException;
+import com.fcgl.madrid.user.payload.ApiResponse;
+import com.fcgl.madrid.user.payload.AuthResponse;
+import com.fcgl.madrid.user.payload.LoginRequest;
+import com.fcgl.madrid.user.payload.SignUpRequest;
+import com.fcgl.madrid.user.repository.UserRepository;
+import com.fcgl.madrid.user.security.TokenProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import java.net.URI;
+
+@Service
+public class AuthService {
+
+    private AuthenticationManager authenticationManager;
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    public AuthService(AuthenticationManager authenticationManager, UserRepository userRepository,
+                       PasswordEncoder passwordEncoder, TokenProvider tokenProvider) {
+        this.authenticationManager = authenticationManager;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.tokenProvider = tokenProvider;
+    }
+
+    public ResponseEntity<?> authenticateUser(LoginRequest loginRequest) {
+        Authentication authentication = authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(
+                        loginRequest.getEmail(),
+                        loginRequest.getPassword()
+                )
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        String token = tokenProvider.createToken(authentication);
+        return ResponseEntity.ok(new AuthResponse(token));
+    }
+
+    public ResponseEntity<?> registerUser(SignUpRequest signUpRequest) {
+        if(userRepository.existsByEmail(signUpRequest.getEmail())) {
+            throw new BadRequestException("Email address already in use.");
+        }
+
+        // Creating user's account
+        User user = new User();
+        user.setName(signUpRequest.getName());
+        user.setEmail(signUpRequest.getEmail());
+        user.setPassword(signUpRequest.getPassword());
+        user.setProvider(AuthProvider.local);
+
+        user.setPassword(passwordEncoder.encode(user.getPassword()));
+
+        User result = userRepository.save(user);
+
+        URI location = ServletUriComponentsBuilder
+                .fromCurrentContextPath().path("/user/me")
+                .buildAndExpand(result.getId()).toUri();
+
+        return ResponseEntity.created(location)
+                .body(new ApiResponse(true, "User registered successfully@"));
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/util/CookieUtils.java
+++ b/src/main/java/com/fcgl/madrid/user/util/CookieUtils.java
@@ -1,0 +1,57 @@
+package com.fcgl.madrid.user.util;
+
+import org.springframework.util.SerializationUtils;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Base64;
+import java.util.Optional;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie: cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        return Base64.getUrlEncoder()
+                .encodeToString(SerializationUtils.serialize(object));
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        return cls.cast(SerializationUtils.deserialize(
+                Base64.getUrlDecoder().decode(cookie.getValue())));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 # Server config
 server:
-  port: ${PORT:8085}
+  port: ${PORT:8080}
 
 # Spring config
 spring:
@@ -10,6 +10,62 @@ spring:
     level:
       org.springframework: WARN
       org.hibernate: WARN
+
+  datasource:
+    url: jdbc:postgresql://db:5432/postgres?useSSL=false
+    username: postgres
+    password: password
+
+  jpa:
+    show-sql: true
+    hibernate:
+      ddl-auto: create-drop
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            clientId: 5014057553-8gm9um6vnli3cle5rgigcdjpdrid14m9.apps.googleusercontent.com
+            clientSecret: tWZKVLxaD_ARWsriiiUFYoIk
+            redirectUriTemplate: "{baseUrl}/oauth2/callback/{registrationId}"
+            scope:
+              - email
+              - profile
+          facebook:
+            clientId: 121189305185277
+            clientSecret: 42ffe5aa7379e8326387e0fe16f34132
+            redirectUriTemplate: "{baseUrl}/oauth2/callback/{registrationId}"
+            scope:
+              - email
+              - public_profile
+          github:
+            clientId: d3e47fc2ddd966fa4352
+            clientSecret: 3bc0f6b8332f93076354c2a5bada2f5a05aea60d
+            redirectUriTemplate: "{baseUrl}/oauth2/callback/{registrationId}"
+            scope:
+              - user:email
+              - read:user
+          provider:
+            facebook:
+              authorizationUri: https://www.facebook.com/v3.0/dialog/oauth
+              tokenUri: https://graph.facebook.com/v3.0/oauth/access_token
+              userInfoUri: https://graph.facebook.com/v3.0/me?fields=id,first_name,middle_name,last_name,name,email,verified,is_verified,picture.width(250).height(250)
+
+app:
+  auth:
+    # TODO: Change these on production
+    tokenSecret: 926D96C90030DD58429D2751AC1BDBBC
+    tokenExpirationMsec: 864000000
+  oauth2:
+    # After successfully authenticating with the OAuth2 Provider,
+    # we'll be generating an auth token for the user and sending the token to the
+    # redirectUri mentioned by the frontend client in the /oauth2/authorize request.
+    # We're not using cookies because they won't work well in mobile clients.
+    authorizedRedirectUris:
+      - http://localhost:3000/oauth2/redirect
+      - myandroidapp://oauth2/redirect
+      - myiosapp://oauth2/redirect
 
 # Eureka config
 eureka:

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,7 @@
+spring.datasource.driver-class-name=org.h2.Driver
+spring.datasource.url=jdbc:h2:mem:db;DB_CLOSE_DELAY=-1
+spring.datasource.username=sa
+spring.datasource.password=sa
+
+#logging.level.org.springframework=OFF
+#logging.level.root=OFF


### PR DESCRIPTION
## Problem
We need a way to authenticate our users. This implementation must allow other services to not have to sign in to use each api

## Solution
* When user signs in. They will be grated a JWT token. This token needs to be passed in the header for every request in order for it to be valid. As long as the JWT token is valid the user has access to their account.

* Add `/signup` and `/login` endpoints

* Add Oatuh2.0 implementation for google. It only works on web... need to look into how to do it for react native

## Test
1. Run and build: `docker-compose up --build`
2. Confirm that you receive a JWT token when login in