### PR TITLE
Change the success and error responses for Login requests

### DIFF
--- a/src/main/java/com/fcgl/madrid/user/controller/AuthController.java
+++ b/src/main/java/com/fcgl/madrid/user/controller/AuthController.java
@@ -1,7 +1,8 @@
 package com.fcgl.madrid.user.controller;
 
-import com.fcgl.madrid.user.payload.LoginRequest;
-import com.fcgl.madrid.user.payload.SignUpRequest;
+import com.fcgl.madrid.user.payload.request.LoginRequest;
+import com.fcgl.madrid.user.payload.request.SignUpRequest;
+import com.fcgl.madrid.user.payload.response.LoginResponse;
 import com.fcgl.madrid.user.service.AuthService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -24,7 +25,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
+    public ResponseEntity<LoginResponse> authenticateUser(@Valid @RequestBody LoginRequest loginRequest) {
         return authService.authenticateUser(loginRequest);
     }
 

--- a/src/main/java/com/fcgl/madrid/user/controller/exceptionHandler/ApiError.java
+++ b/src/main/java/com/fcgl/madrid/user/controller/exceptionHandler/ApiError.java
@@ -1,0 +1,50 @@
+package com.fcgl.madrid.user.controller.exceptionHandler;
+
+import org.springframework.http.HttpStatus;
+import java.util.Arrays;
+import java.util.List;
+
+public class ApiError {
+
+    private HttpStatus status;
+    private String message;
+    private List<String> errors;
+
+    public ApiError(HttpStatus status, String message, List<String> errors) {
+        super();
+        this.status = status;
+        this.message = message;
+        this.errors = errors;
+    }
+
+    public ApiError(HttpStatus status, String message, String error) {
+        super();
+        this.status = status;
+        this.message = message;
+        errors = Arrays.asList(error);
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(HttpStatus status) {
+        this.status = status;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    public void setErrors(List<String> errors) {
+        this.errors = errors;
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/controller/exceptionHandler/CustomExceptionHandler.java
+++ b/src/main/java/com/fcgl/madrid/user/controller/exceptionHandler/CustomExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.fcgl.madrid.user.controller.exceptionHandler;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fcgl.madrid.user.payload.InternalStatus;
+import com.fcgl.madrid.user.payload.StatusCode;
+import com.fcgl.madrid.user.payload.response.LoginResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@ControllerAdvice
+public class CustomExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatus status,
+            WebRequest request) {
+        List<String> errors = new ArrayList<String>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.add(error.getField() + " " + error.getDefaultMessage());
+        }
+        for (ObjectError error : ex.getBindingResult().getGlobalErrors()) {
+            errors.add(error.getObjectName() + " " + error.getDefaultMessage());
+        }
+
+        InternalStatus internalStatus = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, errors);
+        LoginResponse loginResponse = new LoginResponse(internalStatus, null);
+        return handleExceptionInternal(
+                ex, loginResponse, headers, internalStatus.getHttpCode(), request);
+    }
+}

--- a/src/main/java/com/fcgl/madrid/user/payload/InternalStatus.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/InternalStatus.java
@@ -1,0 +1,47 @@
+package com.fcgl.madrid.user.payload;
+
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.ArrayList;
+
+public class InternalStatus {
+    public static final InternalStatus OK = new InternalStatus(StatusCode.OK, HttpStatus.OK, "ok");
+    public static final InternalStatus MISSING_PARAM = new InternalStatus(StatusCode.PARAM, HttpStatus.BAD_REQUEST, "Missing Required Param");
+    public static final InternalStatus NOT_FOUND = new InternalStatus(StatusCode.NOT_FOUND, HttpStatus.NOT_FOUND, "Data Not Found");
+
+    private int code;
+    private HttpStatus httpCode;
+    private List<String> messages;
+
+    public InternalStatus() {
+
+    }
+
+    public InternalStatus(StatusCode statusCode, HttpStatus httpCode, String message) {
+        this.code = statusCode.getCode();
+        this.httpCode = httpCode;
+        this.messages = new ArrayList<String>();
+        this.messages.add(message);
+    }
+
+    public InternalStatus(StatusCode statusCode, HttpStatus httpCode, List<String> messages) {
+        this.code = statusCode.getCode();
+        this.httpCode = httpCode;
+        this.messages = messages;
+    }
+
+
+    public int getCode() {
+        return this.code;
+    }
+
+    public HttpStatus getHttpCode() {
+        return this.httpCode;
+    }
+
+    public List<String> getMessages() {
+        return this.messages;
+    }
+
+}

--- a/src/main/java/com/fcgl/madrid/user/payload/StatusCode.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/StatusCode.java
@@ -1,0 +1,22 @@
+package com.fcgl.madrid.user.payload;
+
+public class StatusCode {
+    public static final StatusCode UNKNOWN = new StatusCode(-1);
+    public static final StatusCode OK = new StatusCode(1);
+    public static final StatusCode PARAM = new StatusCode(2);
+    public static final StatusCode NOT_FOUND = new StatusCode(3);
+    public static final StatusCode AUTH_ERROR = new StatusCode(4);
+
+    private int code;
+
+    StatusCode(int code) {
+        this.code = code;
+    }
+
+
+    public int getCode() {
+        return code;
+    }
+
+}
+

--- a/src/main/java/com/fcgl/madrid/user/payload/request/LoginRequest.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/request/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.user.payload;
+package com.fcgl.madrid.user.payload.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/com/fcgl/madrid/user/payload/request/SignUpRequest.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/request/SignUpRequest.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.user.payload;
+package com.fcgl.madrid.user.payload.request;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/com/fcgl/madrid/user/payload/response/ApiResponse.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/response/ApiResponse.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.user.payload;
+package com.fcgl.madrid.user.payload.response;
 
 public class ApiResponse {
     private boolean success;

--- a/src/main/java/com/fcgl/madrid/user/payload/response/AuthResponse.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/response/AuthResponse.java
@@ -1,4 +1,4 @@
-package com.fcgl.madrid.user.payload;
+package com.fcgl.madrid.user.payload.response;
 
 public class AuthResponse {
     private String accessToken;

--- a/src/main/java/com/fcgl/madrid/user/payload/response/LoginResponse.java
+++ b/src/main/java/com/fcgl/madrid/user/payload/response/LoginResponse.java
@@ -1,0 +1,29 @@
+package com.fcgl.madrid.user.payload.response;
+
+import com.fcgl.madrid.user.payload.InternalStatus;
+
+public class LoginResponse {
+    private InternalStatus internalStatus;
+    private AuthResponse response;
+
+    public LoginResponse(InternalStatus internalStatus, AuthResponse response) {
+        this.internalStatus = internalStatus;
+        this.response = response;
+    }
+
+    public InternalStatus getInternalStatus() {
+        return internalStatus;
+    }
+
+    public void setInternalStatus(InternalStatus internalStatus) {
+        this.internalStatus = internalStatus;
+    }
+
+    public AuthResponse getResponse() {
+        return response;
+    }
+
+    public void setResponse(AuthResponse response) {
+        this.response = response;
+    }
+}


### PR DESCRIPTION
## Problem

Don't have a standard for responses on Success and Error

## Solution
Introduce a standard that API users can expect
The pattern we are going for is son response object that contains an `InternalStatus` object along with any requested data

The `InternalStatus` object contains
    * Custom Status Code
    * HTTP status code
    * List of messages

The `auth/login` endpoint response has been changed to follow the above standard. 

## Test
Make API requests to `auth/login`.

**SUCCESS RESPONSE:**
```
{
    "internalStatus": {
        "code": 1,
        "httpCode": "OK",
        "messages": [
            "ok"
        ]
    },
    "response": {
        "accessToken": "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiZXhwIjoxNTY5MjE5MjY2LCJpYXQiOjE1NjgzNTUyNjYsImF1dGhvcml0aWVzIjpbIlJPTEVfVVNFUiJdfQ.YZJ2eSPLSC0N8tBS4DVrymnHHMOp28B11IhNL1TUzbqDoo71RZ8s6r0XjGT1ntkBAXjUtkgHfio4HQGr42KM2Q",
        "tokenType": "Bearer"
    }
}
```

**ERROR RESPONSE:**
```
{
    "internalStatus": {
        "code": 2,
        "httpCode": "BAD_REQUEST",
        "messages": [
            "email must not be blank",
            "password must not be blank"
        ]
    },
    "response": null
}
```